### PR TITLE
Fixes gh-2: Corrects PIO clock rate calculation.

### DIFF
--- a/src/pio-i2s.c
+++ b/src/pio-i2s.c
@@ -14,8 +14,7 @@ float PioI2S_calculateClockDivision(struct PioI2S* self) {
     float clockSpeed = (float) clock_get_hz(clk_sys);
     float bclkSpeed = (float) self->config->sampleRate *
         (float) PioI2S_NUM_CHANNELS * (float) self->config->bitDepth;
-    float pioSpeed = bclkSpeed * (float) PioI2S_PIO_CYCLES_PER_INSTRUCTION *
-        (float) PioI2S_PIO_INSTRUCTIONS_PER_BIT;
+    float pioSpeed = bclkSpeed * (float) PioI2S_PIO_INSTRUCTIONS_PER_BIT;
     float clockDivision = clockSpeed / pioSpeed;
 
     return clockDivision;

--- a/src/pio-i2s.h
+++ b/src/pio-i2s.h
@@ -2,6 +2,7 @@
 * Copyright 2025 Kinetic Light and Lichen Community Systems
 * Licensed under the BSD-3 License.
 */
+
 #ifndef PIOI2S_H
 #define PIOI2S_H
 
@@ -58,7 +59,6 @@ static inline pio_sm_config PioI2S_out_program_get_default_config(uint offset) {
 /** End compiled version of pio_i2s_out.pio */
 
 
-#define PioI2S_PIO_CYCLES_PER_INSTRUCTION 2
 #define PioI2S_PIO_INSTRUCTIONS_PER_BIT 2
 #define PioI2S_NUM_CHANNELS 2
 


### PR DESCRIPTION
This PR fixes the bit clock rate, ensuring the DAC is clocked at the specified sample rate.

![image](https://github.com/user-attachments/assets/7dfdf9b2-61d0-497e-9a91-8aee3106d888)